### PR TITLE
🐛 Refactor EventProcessor registration timing

### DIFF
--- a/src/main/java/com/github/theword/queqiao/QueQiao.java
+++ b/src/main/java/com/github/theword/queqiao/QueQiao.java
@@ -31,8 +31,8 @@ public class QueQiao {
 
     public QueQiao() {
         MinecraftForge.EVENT_BUS.register(this);
-        MinecraftForge.EVENT_BUS.register(new EventProcessor());
-        FMLCommonHandler.instance().bus().register(new EventProcessor());
+        // MinecraftForge.EVENT_BUS.register(new EventProcessor());
+        // FMLCommonHandler.instance().bus().register(new EventProcessor());
     }
 
     @Mod.EventHandler
@@ -46,6 +46,11 @@ public class QueQiao {
             new HandleApiImpl(),
             new HandleCommandReturnMessageImpl());
         websocketManager.startWebsocketOnServerStart();
+
+        // 在工具类初始化完成之后再注册事件处理器
+        // var eventProcessor = new EventProcessor();
+        MinecraftForge.EVENT_BUS.register(new EventProcessor());
+        FMLCommonHandler.instance().bus().register(new EventProcessor());
     }
 
     @Mod.EventHandler


### PR DESCRIPTION
#81 简单修复了事件注册顺序导致的空指针异常

## Sourcery 总结

错误修复：
- 从构造函数中移除 EventProcessor 注册，并在工具初始化后，在 onServerStarting 中重新注册它，以修复空指针问题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove EventProcessor registration from constructor and re-register it in onServerStarting after tool initialization to fix null pointer issues

</details>